### PR TITLE
escape tag for url special character

### DIFF
--- a/src/render-index.ts
+++ b/src/render-index.ts
@@ -4,6 +4,10 @@ import Sqrl from 'squirrelly'
 
 import { log } from './util'
 
+function escapeTag(tag: string) {
+  return tag.replace(/[&\/\\#, +()$~%.'":*?<>{}]/g, '-');
+}
+
 export function renderIndex(task) {
   const siteMeta = task.data.siteMeta
   const templateProvider = task.tools.templateProvider
@@ -13,6 +17,7 @@ export function renderIndex(task) {
   const indexPath = path.join(outDir, 'index.html')
 
   Sqrl.autoEscaping(false)
+  Sqrl.defineFilter('escapeTag', (str: string) => escapeTag(str))
 
   log.info('Render home page')
   const html = Sqrl.Render(templateProvider.get('index'), {
@@ -27,6 +32,6 @@ export function renderIndex(task) {
       tagName: tagVal,
       pages: pageMetas
     })
-    fs.writeFileSync(`${config.tagDir}/${tagVal}.html`, html, { encoding: 'utf-8' })
+    fs.writeFileSync(`${config.tagDir}/${escapeTag(tagVal)}.html`, html, { encoding: 'utf-8' })
   })
 }


### PR DESCRIPTION
## Issue
The generate process failed when tag cantains special character (e.g. "/")

## Reproduce
1. set a tag with "/" such as "CI/CD" on notion
2. run `notablog generate .`
3. Error as below

```
E/notablog-cli(20200505T234305.045): Error: ENOENT: no such file or directory, open 'public/tag/CI/CD.html'
    at Object.openSync (fs.js:457:3)
    at Object.writeFileSync (fs.js:1282:35)
    at /home/kevink_chen/.nvm/versions/node/v12.16.1/lib/node_modules/notablog/src/render-index.js:34:8
    at Map.forEach (<anonymous>)
    at renderIndex (/home/kevink_chen/.nvm/versions/node/v12.16.1/lib/node_modules/notablog/src/render-index.js:27:19)
    at generate (/home/kevink_chen/.nvm/versions/node/v12.16.1/lib/node_modules/notablog/src/generate.js:90:3)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async cmdGenerate (/home/kevink_chen/.nvm/versions/node/v12.16.1/lib/node_modules/notablog/bin/cli.js:28:5) {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: 'public/tag/CI/CD.html'
}
```
## Solution
replace special character with "-" by using squirrelly filter

reference: 
- https://developers.google.com/maps/documentation/urls/url-encoding
- https://www.geeksforgeeks.org/replace-special-characters-in-a-string-with-underscore-_-in-javascript/