### PR TITLE
Allow link to other pages in table entry

### DIFF
--- a/src/parse-table.js
+++ b/src/parse-table.js
@@ -90,6 +90,18 @@ column with id "${propertyId}" is used`)
    */
 
   /**
+  * Check if page is actually link and replace if necessary.
+  */
+  pagesValid.forEach(page => {
+    if (page.title[0][1]) {
+      let title = page.title[0][1][0][1]['title'];
+      let uri = page.title[0][1][0][1]['uri'];
+      page.title = title;
+      page.uri = uri;
+    }
+  })
+  
+  /**
    * @type {PageMetadata[]}
    */
   let pagesConverted = pagesValid


### PR DESCRIPTION
I added a bit of code that checks and re-maps the properties of an entry if the title is actually a link to another page. I'm sure you can find a better way to access the 'title' and 'uri', but I have very basic knowledge of javascript and could only make it work. I hope this would help others as well! Please let me know if you need me to explain anything.