### PR TITLE
Alternative automatic URL based on slug of title

### DIFF
--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -80,7 +80,7 @@ export async function generate(
 
   /** Fetch site metadata. */
   log.info('Fetch site metadata')
-  const siteContext = await parseTable(config.get('url'), notionAgent)
+  const siteContext = await parseTable(config.get('url') as string, notionAgent, config)
 
   /** Render home page and tags */
   log.info('Render home page and tags')

--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -80,7 +80,7 @@ export async function generate(
 
   /** Fetch site metadata. */
   log.info('Fetch site metadata')
-  const siteContext = await parseTable(config.get('url') as string, notionAgent, config)
+  const siteContext = await parseTable(config.get('url'), notionAgent, config)
 
   /** Render home page and tags */
   log.info('Render home page and tags')

--- a/src/parseTable.ts
+++ b/src/parseTable.ts
@@ -210,11 +210,16 @@ function getDateString(dateRaw: string | undefined): string | undefined {
  * @param {Config} config
  * @returns {string}
  */
-function getPageUrl(pageUri: string, customSlug: string, title: string, config: Config): string {
+function getPageUrl(
+  pageUri: string,
+  customSlug: string,
+  title: string,
+  config: Config
+): string {
   let url = getSafeUrl(customSlug)
   if (url.length === 0) {
-    if (config.get("autoSlug")) {
-      const partialId = extractIdFromUri(pageUri).slice(0, 6);
+    if (config.get('autoSlug')) {
+      const partialId = extractIdFromUri(pageUri).slice(0, 6)
       url = `${getSlugFromTitle(title)}-${partialId}`
     } else {
       url = `${extractIdFromUri(pageUri)}`
@@ -226,11 +231,14 @@ function getPageUrl(pageUri: string, customSlug: string, title: string, config: 
 /**
  * Returns a formatted slug from a title by stripping non-alphanumeric chars, and
  * replacing spaces with dashes.
- * @param {string} title 
+ * @param {string} title
  * @returns {string}
  */
 function getSlugFromTitle(title: string): string {
-  return title.replaceAll(/[\s\\\/]/g, "-").replaceAll(/[^\w-]/g, "").toLowerCase();
+  return title
+    .replaceAll(/[\s\\\/]/g, '-')
+    .replaceAll(/[^\w-]/g, '')
+    .toLowerCase()
 }
 
 /**

--- a/src/parseTable.ts
+++ b/src/parseTable.ts
@@ -201,7 +201,8 @@ function getDateString(dateRaw: string | undefined): string | undefined {
  *
  * First, `/` and `\` are removed since they can't exist in file path.
  * Second, if the escaped url is a empty string or user doesn't specify an
- * url, use page id as the url.
+ * url, generate a slug from the title (if `autoSlug` is `true` in `Config`) and page id,
+ * otherwise use the page id.s
  * @param {string} pageUri
  * @param {string} customSlug
  * @param {string} title
@@ -212,7 +213,7 @@ function getPageUrl(pageUri: string, customSlug: string, title: string, config: 
   var url = getSafeUrl(customSlug)
   if (url.length == 0) {
     if (config.get("autoSlug")) {
-      const partialId = [...extractIdFromUri(pageUri)].slice(0, 6).join("");
+      const partialId = extractIdFromUri(pageUri).slice(0, 6);
       url = `${getSlugFromTitle(title)}-${partialId}`
     } else {
       url = `${extractIdFromUri(pageUri)}`
@@ -228,17 +229,7 @@ function getPageUrl(pageUri: string, customSlug: string, title: string, config: 
  * @returns {string}
  */
 function getSlugFromTitle(title: string): string {
-  var outputSlug: string[] = [];
-  [...title].forEach(char => {
-    if (char.match(/\w/)) {
-      outputSlug.push(char);
-    } else if (char.match(/\s/)) {
-      outputSlug.push("-");
-    } else {
-      return
-    }
-  });
-  return outputSlug.join("");
+  return title.replaceAll(/\s/g, "-").replaceAll(/[^\w-]/g, "").toLowerCase();
 }
 
 /**

--- a/src/parseTable.ts
+++ b/src/parseTable.ts
@@ -213,7 +213,7 @@ function getPageUrl(pageUri: string, customSlug: string, title: string, config: 
   if (url.length == 0) {
     if (config.get("autoSlug")) {
       const partialId = [...extractIdFromUri(pageUri)].slice(0, 6).join("");
-      url = `${partialId}-${getSlugFromTitle(title)}.html`
+      url = `${getSlugFromTitle(title)}-${partialId}.html`
     } else {
       url = `${extractIdFromUri(pageUri)}.html`
     }

--- a/src/parseTable.ts
+++ b/src/parseTable.ts
@@ -213,12 +213,12 @@ function getPageUrl(pageUri: string, customSlug: string, title: string, config: 
   if (url.length == 0) {
     if (config.get("autoSlug")) {
       const partialId = [...extractIdFromUri(pageUri)].slice(0, 6).join("");
-      url = `${getSlugFromTitle(title)}-${partialId}.html`
+      url = `${getSlugFromTitle(title)}-${partialId}`
     } else {
-      url = `${extractIdFromUri(pageUri)}.html`
+      url = `${extractIdFromUri(pageUri)}`
     }
   }
-  return url
+  return `${url}.html`
 }
 
 /**

--- a/src/parseTable.ts
+++ b/src/parseTable.ts
@@ -201,8 +201,9 @@ function getDateString(dateRaw: string | undefined): string | undefined {
  *
  * First, `/` and `\` are removed since they can't exist in file path.
  * Second, if the escaped url is a empty string or user doesn't specify an
- * url, generate a slug from the title (if `autoSlug` is `true` in `Config`) and page id,
- * otherwise use the page id.s
+ * url, generate a slug from the title (if `autoSlug` is `true` in `Config`)
+ * and use it along with page id as the filename,
+ * otherwise just use the page id as is.
  * @param {string} pageUri
  * @param {string} customSlug
  * @param {string} title

--- a/src/parseTable.ts
+++ b/src/parseTable.ts
@@ -211,8 +211,8 @@ function getDateString(dateRaw: string | undefined): string | undefined {
  * @returns {string}
  */
 function getPageUrl(pageUri: string, customSlug: string, title: string, config: Config): string {
-  var url = getSafeUrl(customSlug)
-  if (url.length == 0) {
+  let url = getSafeUrl(customSlug)
+  if (url.length === 0) {
     if (config.get("autoSlug")) {
       const partialId = extractIdFromUri(pageUri).slice(0, 6);
       url = `${getSlugFromTitle(title)}-${partialId}`
@@ -230,7 +230,7 @@ function getPageUrl(pageUri: string, customSlug: string, title: string, config: 
  * @returns {string}
  */
 function getSlugFromTitle(title: string): string {
-  return title.replaceAll(/\s/g, "-").replaceAll(/[^\w-]/g, "").toLowerCase();
+  return title.replaceAll(/[\s\\\/]/g, "-").replaceAll(/[^\w-]/g, "").toLowerCase();
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,7 @@ export interface NotablogStarterConfig {
   url: string
   theme: string
   previewBrowser: string
+  autoSlug: boolean
 }
 
 export interface ThemeConfig {


### PR DESCRIPTION
See: https://github.com/dragonman225/notablog/issues/28

Changes:
- Added new `autoSlug` key (`boolean`) to `NotablogStarterConfig`
- Added new `getSlugFromTitle` function to `parseTable.ts` which strips all non-alphanumeric and non-whitespace characters, and replaces whitespace characters with dash `-`. For example: `Hello, world!` becomes `hello-world`
- Modified `getPageUrl` so that if there is no URL set for the post and `autoSlug` is `true`, then generate the URL to be the output of `getSlugFromTitle` + the first 6 characters of the id -- for example: `hello-world-aabbcc`

Testing:
1. Modify your notablog-starter-template's config.json to have `autoSlug: true`
2. Run `node bin/cli.js generate <path to your notablog> && node bin/cli.js preview <path to your notablog>`
3. Confirm that pages with no custom URLs set have the new slugs