### PR TITLE
Chores: Add husky and lint-staged to run prettier on staged files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ yarn.lock
 dist/
 typedoc/
 test/renderer/*.html
+
+# Lint cache
+.eslintcache

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:renderer": "ts-node --skip-project --log-error test/renderer/renderer.spec.ts",
     "release": "npm run build && npm publish",
     "release:beta": "npm run build && npm publish --tag beta",
-    "upgrade": "node tools/upgrade-deps.js"
+    "upgrade": "node tools/upgrade-deps.js",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@dnpr/cli": "^2.0.0",
@@ -47,6 +48,8 @@
     "eslint": "^7.24.0",
     "eslint-config-prettier": "^8.2.0",
     "eslint-plugin-prettier": "^3.3.1",
+    "husky": "^7.0.4",
+    "lint-staged": "^12.1.4",
     "nast-types": "1.2.1",
     "prettier": "^2.2.1",
     "rollup": "^2.53.3",
@@ -74,5 +77,8 @@
   },
   "engines": {
     "node": ">=15"
+  },
+  "lint-staged": {
+    "*.js": "eslint --cache --fix"
   }
 }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "node": ">=15"
   },
   "lint-staged": {
-    "*.js": "eslint --cache --fix"
+    "*.{js,ts}": "eslint --cache --fix",
+    "*": "prettier --ignore-unknown -w"
   }
 }


### PR DESCRIPTION
Changes:
- Added `husky` and [`lint-staged`](https://github.com/okonet/lint-staged#automatically-fix-code-style-with-prettier-for-any-format-prettier-supports) to `devDependencies`
- Added `prepare` npm script to initialize `husky`
- Added the following `lint-staged` directives:
    - `eslint` for `ts` and `js` files
    - [`prettier`](https://prettier.io/docs/en/precommit.html#option-1-lint-stagedhttpsgithubcomokonetlint-staged) for all files that prettier recognizes

How to test:
1. Pull this branch and run `npm run prepare`
2. Stage a change to a `src/` file which contains lines that prettier will obviously format, for example:
    ```javascript
    console.log("prettier" +
    "will" +
    "lint this")
    ```
3. Commit it with `git commit -m "test commit"`
4. Confirm that `husky` runs `lint-staged` (and by extension, `eslint` and `prettier`). You should see a printout similar to this:
    ![CleanShot 2021-12-29 at 11 04 50](https://user-images.githubusercontent.com/2585982/147623589-7d0c04ca-d174-4bba-8e62-c4769610f833.png)

