### PR TITLE
add optional locale property to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,13 @@ notablog-starter
 
 - `config.json` - User configuration.
 
-  |     Field      |  Type   |                         Description                          |
-  | :------------: | :-----: | :----------------------------------------------------------: |
-  |      url       | string  |     The URL of a Notion table compatible with Notablog.      |
-  |     theme      | string  | The theme to use. It should be one of the folder names in `themes/`. |
-  | previewBrowser | string  |      The path to the browser executable for previewing.      |
-  |    autoSlug    | boolean |      Generate URL slugs for pages without custom ones.       |
+  |     Field      |  Type            |                         Description                          |
+  | :------------: | :--------------: | :----------------------------------------------------------: |
+  |      url       | string           |     The URL of a Notion table compatible with Notablog.      |
+  |     theme      | string           | The theme to use. It should be one of the folder names in `themes/`. |
+  | previewBrowser | string           |      The path to the browser executable for previewing.      |
+  |    autoSlug    | boolean          |      Generate URL slugs for pages without custom ones.       |
+  |    locales     | string/string[]  | The locales which are used to generate string of a date (passed as first argument to Date.prototype.toLocaleDateString()) |
 
 - `public/` - Contains generated static assets.
 

--- a/src/parseTable.ts
+++ b/src/parseTable.ts
@@ -123,7 +123,8 @@ export async function parseTable(
       dateString: getDateString(
         record.propertyCellMap.get(
           propertyAccessMap.get('date') as NDateTimeProperty
-        )?.value?.start_date
+        )?.value?.start_date,
+        config
       ),
       createdTime: record.createdTime,
       lastEditedTime: record.lastEditedTime,
@@ -176,11 +177,14 @@ function renderNodesToHtml(
 
 /**
  * Get formatted string from a date-typed property
- * @param {Nast.Page} page
- * @param {string} propId
+ * @param {string | undefined} dateRaw
+ * @param {Config} config
  * @returns {string | undefined} WWW, MMM DD, YYY
  */
-function getDateString(dateRaw: string | undefined): string | undefined {
+function getDateString(
+  dateRaw: string | undefined,
+  config: Config
+): string | undefined {
   if (dateRaw) {
     const options: Parameters<Date['toLocaleDateString']>['1'] = {
       weekday: 'short',
@@ -188,7 +192,8 @@ function getDateString(dateRaw: string | undefined): string | undefined {
       month: 'short',
       day: 'numeric',
     }
-    const dateString = new Date(dateRaw).toLocaleDateString('en-US', options)
+    const locale = config.get('locale') || 'en-US'
+    const dateString = new Date(dateRaw).toLocaleDateString(locale, options)
     return dateString
   } else return undefined
 }

--- a/src/parseTable.ts
+++ b/src/parseTable.ts
@@ -192,8 +192,8 @@ function getDateString(
       month: 'short',
       day: 'numeric',
     }
-    const locale = config.get('locale') || 'en-US'
-    const dateString = new Date(dateRaw).toLocaleDateString(locale, options)
+    const locales = config.get('locales') || 'en-US'
+    const dateString = new Date(dateRaw).toLocaleDateString(locales, options)
     return dateString
   } else return undefined
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,7 @@ export interface NotablogStarterConfig {
   theme: string
   previewBrowser: string
   autoSlug: boolean
+  locale: string | undefined
 }
 
 export interface ThemeConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,7 +76,7 @@ export interface NotablogStarterConfig {
   theme: string
   previewBrowser: string
   autoSlug: boolean
-  locale: string | undefined
+  locales: string | string[] | undefined
 }
 
 export interface ThemeConfig {


### PR DESCRIPTION
Now date will be formatted according to locale from config (if present), defaults to en-US (as before)